### PR TITLE
add secret access key and secret key length check

### DIFF
--- a/internal/credential/attributes.go
+++ b/internal/credential/attributes.go
@@ -34,12 +34,16 @@ func GetCredentialsConfig(in *structpb.Struct, region string) (*awsutil.Credenti
 	accessKey, err := values.GetStringValue(in, ConstAccessKeyId, true)
 	if err != nil {
 		badFields[fmt.Sprintf("secrets.%s", ConstAccessKeyId)] = err.Error()
+	} else if len(accessKey) != 20 {
+		badFields[fmt.Sprintf("secrets.%s", ConstAccessKeyId)] = "value must be 20 characters"
 	}
 	delete(unknownFields, ConstAccessKeyId)
 
 	secretKey, err := values.GetStringValue(in, ConstSecretAccessKey, true)
 	if err != nil {
 		badFields[fmt.Sprintf("secrets.%s", ConstSecretAccessKey)] = err.Error()
+	} else if len(secretKey) != 40 {
+		badFields[fmt.Sprintf("secrets.%s", ConstSecretAccessKey)] = "value must be 40 characters"
 	}
 	delete(unknownFields, ConstSecretAccessKey)
 

--- a/internal/credential/attributes_test.go
+++ b/internal/credential/attributes_test.go
@@ -120,29 +120,45 @@ func TestGetCredentialsConfig(t *testing.T) {
 			expectedErrContains: "secrets.bar: unrecognized field, secrets.foo: unrecognized field",
 		},
 		{
-			name: "valid ignore creds_last_rotated_time",
+			name: "keys not right length",
 			in: map[string]any{
 				ConstAccessKeyId:          "foobar",
 				ConstSecretAccessKey:      "bazqux",
 				ConstCredsLastRotatedTime: "2006-01-02T15:04:05+07:00",
 			},
+			region:              "us-west-2",
+			expectedErrContains: "secrets.access_key_id: value must be 20 characters, secrets.secret_access_key: value must be 40 characters",
+		},
+		{
+			name:                "getstring error doesn't trigger char len error",
+			in:                  map[string]any{},
+			region:              "us-west-2",
+			expectedErrContains: "[secrets.access_key_id: missing required value \"access_key_id\", secrets.secret_access_key: missing required value \"secret_access_key\"]",
+		},
+		{
+			name: "valid ignore creds_last_rotated_time",
+			in: map[string]any{
+				ConstAccessKeyId:          "foobarbazbuzquintile",
+				ConstSecretAccessKey:      "bazqux-not-thinking-of-40-chars-for-this",
+				ConstCredsLastRotatedTime: "2006-01-02T15:04:05+07:00",
+			},
 			region: "us-west-2",
 			expected: &awsutil.CredentialsConfig{
-				AccessKey: "foobar",
-				SecretKey: "bazqux",
+				AccessKey: "foobarbazbuzquintile",
+				SecretKey: "bazqux-not-thinking-of-40-chars-for-this",
 				Region:    "us-west-2",
 			},
 		},
 		{
 			name: "good",
 			in: map[string]any{
-				ConstAccessKeyId:     "foobar",
-				ConstSecretAccessKey: "bazqux",
+				ConstAccessKeyId:     "foobarbazbuzquintile",
+				ConstSecretAccessKey: "bazqux-not-thinking-of-40-chars-for-this",
 			},
 			region: "us-west-2",
 			expected: &awsutil.CredentialsConfig{
-				AccessKey: "foobar",
-				SecretKey: "bazqux",
+				AccessKey: "foobarbazbuzquintile",
+				SecretKey: "bazqux-not-thinking-of-40-chars-for-this",
 				Region:    "us-west-2",
 			},
 		},


### PR DESCRIPTION
validates that `secrets.access_key_id` is always 20 characters long and `secrets.secret_access_key` is always 40 characters long