### PR TITLE
fix(host): catch dry run validation error

### DIFF
--- a/plugin/service/host/plugin.go
+++ b/plugin/service/host/plugin.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
-	awserr "github.com/aws/smithy-go"
+	"github.com/aws/smithy-go"
 	pb "github.com/hashicorp/boundary/sdk/pbs/plugin"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -351,7 +351,8 @@ func (p *HostPlugin) OnCreateSet(ctx context.Context, req *pb.OnCreateSetRequest
 		return nil, status.Error(codes.FailedPrecondition, "query error: DescribeInstances DryRun should have returned error, but none was found")
 	}
 
-	if awsErr, ok := err.(awserr.APIError); ok && awsErr.ErrorCode() == "DryRunOperation" {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "DryRunOperation" {
 		// Success
 		return &pb.OnCreateSetResponse{}, nil
 	}
@@ -427,7 +428,8 @@ func (p *HostPlugin) OnUpdateSet(ctx context.Context, req *pb.OnUpdateSetRequest
 		return nil, status.Error(codes.FailedPrecondition, "query error: DescribeInstances DryRun should have returned error, but none was found")
 	}
 
-	if awsErr, ok := err.(awserr.APIError); ok && awsErr.ErrorCode() == "DryRunOperation" {
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "DryRunOperation" {
 		// Success
 		return &pb.OnUpdateSetResponse{}, nil
 	}


### PR DESCRIPTION
# Summary:

This PR fixes a bug where the code failed to catch the dry run validation error for create/update host sets. This was found when running end2end tests in boundary:
```
{"context":"Error from controller when performing create on plugin-type host set","status_code":500,"status":500,"api_error":{"kind":"Internal","message":"host_sets.(Service).createInRepo: unable to create host set: plugin.(Repository).CreateSet: in catalog: hcplg_4MFWpRx2i0: db.DoTx: plugin.(Repository).CreateSet: unknown, unknown: error #0: rpc error: code = InvalidArgument desc = error performing dry run of DescribeInstances: operation error EC2: DescribeInstances, https response error StatusCode: 412, RequestID: 2c3cc0fe-3689-4d13-8449-9cab8aacafa7, api error DryRunOperation: Request would have succeeded, but DryRun flag is set."}}
```

The expected behavior is to catch this error: `Request would have succeeded, but DryRun flag is set` and return a success.