### PR TITLE
fix(credential): Allow for static AWS credentials in environment

### DIFF
--- a/internal/credential/state.go
+++ b/internal/credential/state.go
@@ -196,7 +196,13 @@ func (s *AwsCredentialPersistedState) DeleteCreds(ctx context.Context) error {
 
 // GenerateCredentialChain returns a AWS configuration for the credentials in the state.
 func (s *AwsCredentialPersistedState) GenerateCredentialChain(ctx context.Context) (*aws.Config, error) {
-	return s.CredentialsConfig.GenerateCredentialChain(ctx, s.testOpts...)
+	// Default `WithSharedCredentials` is `true` - This disables the ability to
+	// read credentials from environment variables because we set the default
+	// profile options, so we need to set it to false (see
+	// awsutil@v2.(*CredentialsConfig).generateAwsConfigOptions) for extra
+	// details.
+	opts := append(s.testOpts, awsutil.WithSharedCredentials(false))
+	return s.CredentialsConfig.GenerateCredentialChain(ctx, opts...)
 }
 
 // ToMap returns a map of the credentials stored in the persisted state.


### PR DESCRIPTION
This commit fixes a problem where the plugin/AWS SDK would not recognise static AWS credentials set in the machine's environment variables (by setting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)

The default `WithSharedCredentials` value is `true` in awsutil (v2) - This essentially disables the ability to read credentials from the environment because we set the `default` AWS profile options, making the SDK go search for a profile that may not exist and ignoring the environment in the way, so we need to set it to `false` (see `awsutil@v2.(*CredentialsConfig).generateAwsConfigOptions`) for extra details.