### PR TITLE
feat(service): Add support for host plugin AssumeRole

### DIFF
--- a/internal/credential/attributes.go
+++ b/internal/credential/attributes.go
@@ -37,7 +37,7 @@ type CredentialAttributes struct {
 // CredentialsConfig used for configuring an AWS session. An status error is returned
 // with an InvalidArgument code if any unrecognized fields are found in the protobuf
 // struct input.
-func GetCredentialsConfig(secrets *structpb.Struct, attrs *CredentialAttributes, required bool) (*awsutil.CredentialsConfig, error) {
+func GetCredentialsConfig(secrets *structpb.Struct, attrs *CredentialAttributes) (*awsutil.CredentialsConfig, error) {
 	// initialize secrets if it is nil
 	// secrets can be nil because static credentials are optional
 	if secrets == nil {
@@ -49,13 +49,13 @@ func GetCredentialsConfig(secrets *structpb.Struct, attrs *CredentialAttributes,
 	unknownFields := values.StructFields(secrets)
 	badFields := make(map[string]string)
 
-	accessKey, err := values.GetStringValue(secrets, ConstAccessKeyId, required)
+	accessKey, err := values.GetStringValue(secrets, ConstAccessKeyId, false)
 	if err != nil {
 		badFields[fmt.Sprintf("secrets.%s", ConstAccessKeyId)] = err.Error()
 	}
 	delete(unknownFields, ConstAccessKeyId)
 
-	secretKey, err := values.GetStringValue(secrets, ConstSecretAccessKey, required)
+	secretKey, err := values.GetStringValue(secrets, ConstSecretAccessKey, false)
 	if err != nil {
 		badFields[fmt.Sprintf("secrets.%s", ConstSecretAccessKey)] = err.Error()
 	}

--- a/internal/credential/attributes_test.go
+++ b/internal/credential/attributes_test.go
@@ -105,7 +105,6 @@ func TestGetCredentialsConfig(t *testing.T) {
 	cases := []struct {
 		name                string
 		secrets             *structpb.Struct
-		required            bool
 		attrs               *CredentialAttributes
 		expected            *awsutil.CredentialsConfig
 		expectedErrContains string
@@ -135,32 +134,6 @@ func TestGetCredentialsConfig(t *testing.T) {
 				SecretKey: "bazqux",
 				Region:    "us-west-2",
 			},
-		},
-		{
-			name: "missing access key",
-			secrets: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					ConstSecretAccessKey: structpb.NewStringValue("bazqux"),
-				},
-			},
-			attrs: &CredentialAttributes{
-				Region: "us-west-2",
-			},
-			required:            true,
-			expectedErrContains: "secrets.access_key_id: missing required value",
-		},
-		{
-			name: "missing secret key",
-			secrets: &structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					ConstAccessKeyId: structpb.NewStringValue("AKIAfoobar"),
-				},
-			},
-			required: true,
-			attrs: &CredentialAttributes{
-				Region: "us-west-2",
-			},
-			expectedErrContains: "secrets.secret_access_key: missing required value",
 		},
 		{
 			name: "unknown fields",
@@ -260,7 +233,7 @@ func TestGetCredentialsConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			actual, err := GetCredentialsConfig(tc.secrets, tc.attrs, tc.required)
+			actual, err := GetCredentialsConfig(tc.secrets, tc.attrs)
 			if tc.expectedErrContains != "" {
 				require.Error(err)
 				require.Contains(err.Error(), tc.expectedErrContains)

--- a/plugin/service/host/plugin.go
+++ b/plugin/service/host/plugin.go
@@ -51,7 +51,7 @@ func (p *HostPlugin) OnCreateCatalog(ctx context.Context, req *pb.OnCreateCatalo
 	if err != nil {
 		return nil, err
 	}
-	credConfig, err := credential.GetCredentialsConfig(catalog.GetSecrets(), catalogAttributes.CredentialAttributes, false)
+	credConfig, err := credential.GetCredentialsConfig(catalog.GetSecrets(), catalogAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func (p *HostPlugin) OnUpdateCatalog(ctx context.Context, req *pb.OnUpdateCatalo
 	// Verify the incoming credentials are valid and return any errors to the
 	// user if they're not. Note this doesn't validate the credentials against
 	// AWS - it only does logical validation on the fields.
-	updatedCredentials, err := credential.GetCredentialsConfig(newCatalog.GetSecrets(), newCatalogAttributes.CredentialAttributes, false)
+	updatedCredentials, err := credential.GetCredentialsConfig(newCatalog.GetSecrets(), newCatalogAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/service/host/plugin_test.go
+++ b/plugin/service/host/plugin_test.go
@@ -9,10 +9,14 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/boundary-plugin-aws/internal/credential"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostcatalogs"
 	"github.com/hashicorp/boundary/sdk/pbs/controller/api/resources/hostsets"
@@ -21,8 +25,549 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+func TestPluginOnCreateCatalogSuccess(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         *pb.OnCreateCatalogRequest
+		credOpts    []credential.AwsCredentialPersistedStateOption
+		catalogOpts []awsCatalogPersistedStateOption
+		expRsp      *pb.OnCreateCatalogResponse
+	}{
+		{
+			name: "usingStaticCredentials",
+			req: &pb.OnCreateCatalogRequest{
+				Catalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			expRsp: &pb.OnCreateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "usingRotatedStaticCredentials",
+			req: &pb.OnCreateCatalogRequest{
+				Catalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithSTSAPIFunc(awsutil.NewMockSTS()),
+					awsutil.WithIAMAPIFunc(
+						awsutil.NewMockIAM(
+							awsutil.WithGetUserOutput(
+								&iam.GetUserOutput{
+									User: &iamTypes.User{
+										Arn:      aws.String("arn:aws:iam::123456789012:user/JohnDoe"),
+										UserId:   aws.String("AIDAJQABLZS4A3QDU576Q"),
+										UserName: aws.String("JohnDoe"),
+									},
+								},
+							),
+							awsutil.WithCreateAccessKeyOutput(
+								&iam.CreateAccessKeyOutput{
+									AccessKey: &iamTypes.AccessKey{
+										AccessKeyId:     aws.String("AKIArotated"),
+										SecretAccessKey: aws.String("rotated_secret"),
+										UserName:        aws.String("JohnDoe"),
+									},
+								},
+							),
+						),
+					),
+				}),
+			},
+			expRsp: &pb.OnCreateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIArotated"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("rotated_secret"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "usingAssumeRole",
+			req: &pb.OnCreateCatalogRequest{
+				Catalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			expRsp: &pb.OnCreateCatalogResponse{Persisted: &pb.HostCatalogPersisted{Secrets: &structpb.Struct{}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &HostPlugin{
+				testCredStateOpts:    tt.credOpts,
+				testCatalogStateOpts: tt.catalogOpts,
+			}
+			rsp, err := p.OnCreateCatalog(context.Background(), tt.req)
+			require.NoError(t, err)
+
+			delete(rsp.GetPersisted().GetSecrets().GetFields(), credential.ConstCredsLastRotatedTime)
+			require.Empty(t, cmp.Diff(tt.expRsp, rsp, protocmp.Transform()))
+		})
+	}
+}
+
+func TestPluginOnUpdateCatalogSuccess(t *testing.T) {
+	// static -> static rotated
+	// static -> dynamic
+
+	// static rotated -> static
+	// static rotated -> dynamic
+
+	// dynamic -> static
+	// dynamic -> static rotated
+
+	tests := []struct {
+		name        string
+		req         *pb.OnUpdateCatalogRequest
+		credOpts    []credential.AwsCredentialPersistedStateOption
+		catalogOpts []awsCatalogPersistedStateOption
+		expRsp      *pb.OnUpdateCatalogResponse
+	}{
+		{
+			name: "staticCredentialToStaticRotated",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnewcred"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("newcred"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIApersisted"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("persisted"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue(time.Time{}.Format(time.RFC3339Nano)),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithSTSAPIFunc(awsutil.NewMockSTS()),
+					awsutil.WithIAMAPIFunc(
+						awsutil.NewMockIAM(
+							awsutil.WithGetUserOutput(
+								&iam.GetUserOutput{
+									User: &iamTypes.User{
+										Arn:      aws.String("arn:aws:iam::123456789012:user/JohnDoe"),
+										UserId:   aws.String("AIDAJQABLZS4A3QDU576Q"),
+										UserName: aws.String("JohnDoe"),
+									},
+								},
+							),
+							awsutil.WithCreateAccessKeyOutput(
+								&iam.CreateAccessKeyOutput{
+									AccessKey: &iamTypes.AccessKey{
+										AccessKeyId:     aws.String("AKIArotated"),
+										SecretAccessKey: aws.String("rotated_secret"),
+										UserName:        aws.String("JohnDoe"),
+									},
+								},
+							),
+						),
+					),
+				}),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIArotated"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("rotated_secret"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "staticCredentialToAssumeRole",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+							},
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIApersisted"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("persisted"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue(time.Time{}.Format(time.RFC3339Nano)),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{Secrets: &structpb.Struct{}},
+			},
+		},
+		{
+			name: "staticRotatedCredentialToStatic",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnotrotated"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("notrotated"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIApersisted"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("persisted"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue(time.Now().Format(time.RFC3339Nano)),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithIAMAPIFunc(awsutil.NewMockIAM()),
+				}),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnotrotated"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("notrotated"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "staticRotatedCredentialToAssumeRole",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+							},
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIApersisted"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("persisted"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue(time.Now().Format(time.RFC3339Nano)),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithIAMAPIFunc(awsutil.NewMockIAM()),
+				}),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{},
+				},
+			},
+		},
+		{
+			name: "assumeRoleCredentialToStatic",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnew"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("new"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{Secrets: &structpb.Struct{}},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnew"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("new"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "assumeRoleCredentialToStaticRotated",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAnew"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("new"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{Secrets: &structpb.Struct{}},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithSTSAPIFunc(awsutil.NewMockSTS()),
+					awsutil.WithIAMAPIFunc(
+						awsutil.NewMockIAM(
+							awsutil.WithGetUserOutput(
+								&iam.GetUserOutput{
+									User: &iamTypes.User{
+										Arn:      aws.String("arn:aws:iam::123456789012:user/JohnDoe"),
+										UserId:   aws.String("AIDAJQABLZS4A3QDU576Q"),
+										UserName: aws.String("JohnDoe"),
+									},
+								},
+							),
+							awsutil.WithCreateAccessKeyOutput(
+								&iam.CreateAccessKeyOutput{
+									AccessKey: &iamTypes.AccessKey{
+										AccessKeyId:     aws.String("AKIArotated"),
+										SecretAccessKey: aws.String("rotated_secret"),
+										UserName:        aws.String("JohnDoe"),
+									},
+								},
+							),
+						),
+					),
+				}),
+			},
+			expRsp: &pb.OnUpdateCatalogResponse{
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIArotated"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("rotated_secret"),
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &HostPlugin{
+				testCredStateOpts:    tt.credOpts,
+				testCatalogStateOpts: tt.catalogOpts,
+			}
+			rsp, err := p.OnUpdateCatalog(context.Background(), tt.req)
+			require.NoError(t, err)
+
+			delete(rsp.GetPersisted().GetSecrets().GetFields(), credential.ConstCredsLastRotatedTime)
+			require.Empty(t, cmp.Diff(tt.expRsp, rsp, protocmp.Transform()))
+		})
+	}
+}
 
 func TestPluginOnCreateCatalogErr(t *testing.T) {
 	cases := []struct {
@@ -36,7 +581,7 @@ func TestPluginOnCreateCatalogErr(t *testing.T) {
 		{
 			name:                "nil catalog",
 			req:                 &pb.OnCreateCatalogRequest{},
-			expectedErrContains: "catalog is nil",
+			expectedErrContains: "catalog is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -63,24 +608,30 @@ func TestPluginOnCreateCatalogErr(t *testing.T) {
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
-			name: "error reading secrets",
+			name: "failed to build credentials config",
 			req: &pb.OnCreateCatalogRequest{
 				Catalog: &hostcatalogs.HostCatalog{
-					Secrets: new(structpb.Struct),
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bazqux"),
+						},
+					},
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
 						Attributes: &structpb.Struct{
 							Fields: map[string]*structpb.Value{
-								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
+								credential.ConstRegion:  structpb.NewStringValue("us-west-2"),
+								credential.ConstRoleArn: structpb.NewStringValue("arn:0123:test:rolearn"),
 							},
 						},
 					},
 				},
 			},
-			expectedErrContains: "missing required value \"access_key_id\"",
+			expectedErrContains: "Error in the secrets provided: [attributes.role_arn: conflicts with access_key_id and secret_access_key values, secrets.access_key_id: conflicts with role_arn value, secrets.secret_access_key: conflicts with role_arn value]",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
-			name: "persisted state setup error",
+			name: "credential persisted state setup error",
 			req: &pb.OnCreateCatalogRequest{
 				Catalog: &hostcatalogs.HostCatalog{
 					Secrets: &structpb.Struct{
@@ -97,8 +648,8 @@ func TestPluginOnCreateCatalogErr(t *testing.T) {
 					},
 				},
 			},
-			catalogOpts: []awsCatalogPersistedStateOption{
-				func(s *awsCatalogPersistedState) error {
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				func(s *credential.AwsCredentialPersistedState) error {
 					return errors.New(testOptionErr)
 				},
 			},
@@ -132,7 +683,34 @@ func TestPluginOnCreateCatalogErr(t *testing.T) {
 					),
 				}),
 			},
-			expectedErrContains: "aws service unknown: unknown error: error rotating credentials",
+			expectedErrContains: "error rotating credentials",
+			expectedErrCode:     codes.Unknown,
+		},
+		{
+			name: "catalog persisted state error",
+			req: &pb.OnCreateCatalogRequest{
+				Catalog: &hostcatalogs.HostCatalog{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bazqux"),
+						}},
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-west-2"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				func(s *awsCatalogPersistedState) error {
+					return fmt.Errorf("oops there was an error")
+				},
+			},
+			expectedErrContains: "error setting up persisted state: oops there was an error",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -154,17 +732,14 @@ func TestPluginOnCreateCatalogErr(t *testing.T) {
 					},
 				},
 			},
-			credOpts: []credential.AwsCredentialPersistedStateOption{
-				credential.WithStateTestOpts([]awsutil.Option{
-					awsutil.WithSTSAPIFunc(
-						awsutil.NewMockSTS(
-							awsutil.WithGetCallerIdentityError(errors.New(testGetCallerIdentityErr)),
-						),
-					),
-				}),
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesError(errors.New(testDescribeInstancesError)),
+				)),
 			},
-			expectedErrContains: "aws service unknown: unknown error: validating credentials",
-			expectedErrCode:     codes.InvalidArgument,
+			expectedErrContains: "aws describe instances failed: DescribeInstances error",
+			expectedErrCode:     codes.FailedPrecondition,
 		},
 	}
 
@@ -194,24 +769,94 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 		expectedErrCode     codes.Code
 	}{
 		{
-			name:                "nil new catalog",
-			req:                 &pb.OnUpdateCatalogRequest{},
-			expectedErrContains: "new catalog is nil",
+			name: "nil current catalog",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: nil,
+				NewCatalog:     &hostcatalogs.HostCatalog{},
+				Persisted:      &pb.HostCatalogPersisted{},
+			},
+			expectedErrContains: "current catalog is required",
+			expectedErrCode:     codes.InvalidArgument,
+		},
+		{
+			name: "nil new catalog",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{},
+				NewCatalog:     nil,
+				Persisted:      &pb.HostCatalogPersisted{},
+			},
+			expectedErrContains: "new catalog is required",
+			expectedErrCode:     codes.InvalidArgument,
+		},
+		{
+			name: "nil current attributes",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: nil,
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{},
+				},
+			},
+			expectedErrContains: "current catalog attributes are required",
+			expectedErrCode:     codes.InvalidArgument,
+		},
+		{
+			name: "error reading current catalog attributes",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{},
+					},
+				},
+			},
+			expectedErrContains: "missing required value \"region\"",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
 			name: "nil new attributes",
 			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
 				NewCatalog: &hostcatalogs.HostCatalog{
-					Secrets: new(structpb.Struct),
+					Attrs: nil,
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{},
 				},
 			},
-			expectedErrContains: "new catalog missing attributes",
+			expectedErrContains: "new catalog attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
-			name: "error reading attributes",
+			name: "error reading new catalog attributes",
 			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
 				NewCatalog: &hostcatalogs.HostCatalog{
 					Secrets: new(structpb.Struct),
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
@@ -223,8 +868,17 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
-			name: "persisted state setup error",
+			name: "credential persisted state setup error",
 			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
 				NewCatalog: &hostcatalogs.HostCatalog{
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
 						Attributes: &structpb.Struct{
@@ -244,8 +898,8 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 					},
 				},
 			},
-			catalogOpts: []awsCatalogPersistedStateOption{
-				func(s *awsCatalogPersistedState) error {
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				func(s *credential.AwsCredentialPersistedState) error {
 					return errors.New(testOptionErr)
 				},
 			},
@@ -253,8 +907,203 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
+			name: "get new credentials config error",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:  structpb.NewStringValue("us-west-2"),
+								credential.ConstRoleArn: structpb.NewStringValue("arn:0123:test:rolearn"),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
+						},
+					},
+				},
+			},
+			expectedErrContains: "Error in the secrets provided: [attributes.role_arn: conflicts with access_key_id and secret_access_key values, secrets.access_key_id: conflicts with role_arn value, secrets.secret_access_key: conflicts with role_arn value]",
+			expectedErrCode:     codes.InvalidArgument,
+		},
+		{
+			name: "new incoming static credential update dry run error",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesError(errors.New(testDescribeInstancesError)),
+				)),
+			},
+			expectedErrContains: "aws describe instances failed: DescribeInstances error",
+			expectedErrCode:     codes.FailedPrecondition,
+		},
+		{
+			name: "new incoming dynamic credential update dry run error",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-east-1"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-west-2"),
+								credential.ConstRoleArn:                   structpb.NewStringValue("arn:0123:test:rolearn"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesError(errors.New(testDescribeInstancesError)),
+				)),
+			},
+			expectedErrContains: "aws describe instances failed: DescribeInstances error",
+			expectedErrCode:     codes.FailedPrecondition,
+		},
+		{
+			name: "replace creds error",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-east-1"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion:                    structpb.NewStringValue("us-west-2"),
+								credential.ConstDisableCredentialRotation: structpb.NewBoolValue(true),
+							},
+						},
+					},
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIAfoo"),
+							credential.ConstSecretAccessKey: structpb.NewStringValue("bar"),
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{}),
+				)),
+			},
+			credOpts: []credential.AwsCredentialPersistedStateOption{
+				credential.WithStateTestOpts([]awsutil.Option{
+					awsutil.WithIAMAPIFunc(
+						awsutil.NewMockIAM(
+							awsutil.WithDeleteAccessKeyError(fmt.Errorf("oops delete fail")),
+						),
+					),
+				}),
+			},
+			expectedErrContains: "failed to delete access key",
+			expectedErrCode:     codes.Unknown,
+		},
+		{
 			name: "cannot disable rotation for already rotated credentials",
 			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
+							},
+						},
+					},
+				},
 				NewCatalog: &hostcatalogs.HostCatalog{
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
 						Attributes: &structpb.Struct{
@@ -276,44 +1125,12 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 				},
 			},
 			expectedErrContains: "cannot disable rotation for already-rotated credentials",
-			expectedErrCode:     codes.FailedPrecondition,
-		},
-		{
-			name: "error reading secrets",
-			req: &pb.OnUpdateCatalogRequest{
-				NewCatalog: &hostcatalogs.HostCatalog{
-					Secrets: new(structpb.Struct),
-					Attrs: &hostcatalogs.HostCatalog_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
-							},
-						},
-					},
-				},
-				Persisted: &pb.HostCatalogPersisted{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
-							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
-							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
-						},
-					},
-				},
-			},
-			expectedErrContains: "missing required value \"access_key_id\"",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
-			name: "updating secrets, replace error",
+			name: "rotation error",
 			req: &pb.OnUpdateCatalogRequest{
-				NewCatalog: &hostcatalogs.HostCatalog{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:     structpb.NewStringValue("AKIA_onetwo"),
-							credential.ConstSecretAccessKey: structpb.NewStringValue("threefour"),
-						},
-					},
+				CurrentCatalog: &hostcatalogs.HostCatalog{
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
 						Attributes: &structpb.Struct{
 							Fields: map[string]*structpb.Value{
@@ -323,31 +1140,6 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 						},
 					},
 				},
-				Persisted: &pb.HostCatalogPersisted{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
-							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
-							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
-						},
-					},
-				},
-			},
-			credOpts: []credential.AwsCredentialPersistedStateOption{
-				credential.WithStateTestOpts([]awsutil.Option{
-					awsutil.WithIAMAPIFunc(
-						awsutil.NewMockIAM(
-							awsutil.WithDeleteAccessKeyError(errors.New(testDeleteAccessKeyErr)),
-						),
-					),
-				}),
-			},
-			expectedErrContains: "aws service unknown: unknown error: failed to delete access key",
-			expectedErrCode:     codes.InvalidArgument,
-		},
-		{
-			name: "rotation error",
-			req: &pb.OnUpdateCatalogRequest{
 				NewCatalog: &hostcatalogs.HostCatalog{
 					Attrs: &hostcatalogs.HostCatalog_Attributes{
 						Attributes: &structpb.Struct{
@@ -375,8 +1167,48 @@ func TestPluginOnUpdateCatalogErr(t *testing.T) {
 					),
 				}),
 			},
-			expectedErrContains: "aws service unknown: unknown error: error rotating credentials",
-			expectedErrCode:     codes.InvalidArgument,
+			expectedErrContains: "error rotating credentials",
+			expectedErrCode:     codes.Unknown,
+		},
+		{
+			name: "final dry run fail",
+			req: &pb.OnUpdateCatalogRequest{
+				CurrentCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
+							},
+						},
+					},
+				},
+				NewCatalog: &hostcatalogs.HostCatalog{
+					Attrs: &hostcatalogs.HostCatalog_Attributes{
+						Attributes: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
+							},
+						},
+					},
+				},
+				Persisted: &pb.HostCatalogPersisted{
+					Secrets: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
+							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
+							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
+						},
+					},
+				},
+			},
+			catalogOpts: []awsCatalogPersistedStateOption{
+				withTestEC2APIFunc(newTestMockEC2(
+					nil,
+					testMockEC2WithDescribeInstancesError(fmt.Errorf("oops there was an error")),
+				)),
+			},
+			expectedErrContains: "aws describe instances failed: oops there was an error",
+			expectedErrCode:     codes.FailedPrecondition,
 		},
 	}
 
@@ -467,7 +1299,7 @@ func TestPluginOnDeleteCatalogErr(t *testing.T) {
 				}),
 			},
 			expectedErrContains: "aws service unknown: unknown error: failed to delete access key",
-			expectedErrCode:     codes.Aborted,
+			expectedErrCode:     codes.Unknown,
 		},
 	}
 
@@ -499,7 +1331,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 		{
 			name:                "nil catalog",
 			req:                 &pb.OnCreateSetRequest{},
-			expectedErrContains: "catalog is nil",
+			expectedErrContains: "catalog is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -509,7 +1341,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 					Secrets: new(structpb.Struct),
 				},
 			},
-			expectedErrContains: "catalog missing attributes",
+			expectedErrContains: "catalog attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -577,7 +1409,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 					},
 				},
 			},
-			expectedErrContains: "set is nil",
+			expectedErrContains: "set is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -603,7 +1435,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 				},
 				Set: &hostsets.HostSet{},
 			},
-			expectedErrContains: "set missing attributes",
+			expectedErrContains: "set attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -729,97 +1561,7 @@ func TestPluginOnCreateSetErr(t *testing.T) {
 					testMockEC2WithDescribeInstancesError(errors.New(testDescribeInstancesError)),
 				)),
 			},
-			expectedErrContains: fmt.Sprintf("error performing dry run of DescribeInstances: %s", testDescribeInstancesError),
-			expectedErrCode:     codes.InvalidArgument,
-		},
-		{
-			name: "DescribeInstances non-error array filter",
-			req: &pb.OnCreateSetRequest{
-				Catalog: &hostcatalogs.HostCatalog{
-					Attrs: &hostcatalogs.HostCatalog_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
-							},
-						},
-					},
-				},
-				Persisted: &pb.HostCatalogPersisted{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
-							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
-							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
-						},
-					},
-				},
-				Set: &hostsets.HostSet{
-					Attrs: &hostsets.HostSet_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								ConstDescribeInstancesFilters: structpb.NewListValue(
-									&structpb.ListValue{
-										Values: []*structpb.Value{
-											structpb.NewStringValue("tag-key=foo"),
-										},
-									},
-								),
-							},
-						},
-					},
-				},
-			},
-			catalogOpts: []awsCatalogPersistedStateOption{
-				withTestEC2APIFunc(newTestMockEC2(
-					nil,
-				)),
-			},
-			expectedErrContains: "query error: DescribeInstances DryRun should have returned error, but none was found",
-			expectedErrCode:     codes.FailedPrecondition,
-		},
-		{
-			name: "DescribeInstances non-error string filter",
-			req: &pb.OnCreateSetRequest{
-				Catalog: &hostcatalogs.HostCatalog{
-					Attrs: &hostcatalogs.HostCatalog_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
-							},
-						},
-					},
-				},
-				Persisted: &pb.HostCatalogPersisted{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
-							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
-							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
-						},
-					},
-				},
-				Set: &hostsets.HostSet{
-					Attrs: &hostsets.HostSet_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								ConstDescribeInstancesFilters: structpb.NewListValue(
-									&structpb.ListValue{
-										Values: []*structpb.Value{
-											structpb.NewStringValue("tag-key=foo"),
-										},
-									},
-								),
-							},
-						},
-					},
-				},
-			},
-			catalogOpts: []awsCatalogPersistedStateOption{
-				withTestEC2APIFunc(newTestMockEC2(
-					nil,
-				)),
-			},
-			expectedErrContains: "query error: DescribeInstances DryRun should have returned error, but none was found",
+			expectedErrContains: fmt.Sprintf("aws describe instances failed: %s", testDescribeInstancesError),
 			expectedErrCode:     codes.FailedPrecondition,
 		},
 	}
@@ -852,7 +1594,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 		{
 			name:                "nil catalog",
 			req:                 &pb.OnUpdateSetRequest{},
-			expectedErrContains: "catalog is nil",
+			expectedErrContains: "catalog is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -862,7 +1604,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 					Secrets: new(structpb.Struct),
 				},
 			},
-			expectedErrContains: "catalog missing attributes",
+			expectedErrContains: "catalog attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -930,7 +1672,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 					},
 				},
 			},
-			expectedErrContains: "new set is nil",
+			expectedErrContains: "new set is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -956,7 +1698,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 				},
 				NewSet: &hostsets.HostSet{},
 			},
-			expectedErrContains: "new set missing attributes",
+			expectedErrContains: "new set attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1082,52 +1824,7 @@ func TestPluginOnUpdateSetErr(t *testing.T) {
 					testMockEC2WithDescribeInstancesError(errors.New(testDescribeInstancesError)),
 				)),
 			},
-			expectedErrContains: fmt.Sprintf("error performing dry run of DescribeInstances: %s", testDescribeInstancesError),
-			expectedErrCode:     codes.InvalidArgument,
-		},
-		{
-			name: "DescribeInstances non-error",
-			req: &pb.OnUpdateSetRequest{
-				Catalog: &hostcatalogs.HostCatalog{
-					Attrs: &hostcatalogs.HostCatalog_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								credential.ConstRegion: structpb.NewStringValue("us-west-2"),
-							},
-						},
-					},
-				},
-				Persisted: &pb.HostCatalogPersisted{
-					Secrets: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							credential.ConstAccessKeyId:          structpb.NewStringValue("AKIA_foobar"),
-							credential.ConstSecretAccessKey:      structpb.NewStringValue("bazqux"),
-							credential.ConstCredsLastRotatedTime: structpb.NewStringValue("2006-01-02T15:04:05+07:00"),
-						},
-					},
-				},
-				NewSet: &hostsets.HostSet{
-					Attrs: &hostsets.HostSet_Attributes{
-						Attributes: &structpb.Struct{
-							Fields: map[string]*structpb.Value{
-								ConstDescribeInstancesFilters: structpb.NewListValue(
-									&structpb.ListValue{
-										Values: []*structpb.Value{
-											structpb.NewStringValue("tag-key=foo"),
-										},
-									},
-								),
-							},
-						},
-					},
-				},
-			},
-			catalogOpts: []awsCatalogPersistedStateOption{
-				withTestEC2APIFunc(newTestMockEC2(
-					nil,
-				)),
-			},
-			expectedErrContains: "query error: DescribeInstances DryRun should have returned error, but none was found",
+			expectedErrContains: fmt.Sprintf("aws describe instances failed: %s", testDescribeInstancesError),
 			expectedErrCode:     codes.FailedPrecondition,
 		},
 	}
@@ -1160,7 +1857,7 @@ func TestPluginListHostsErr(t *testing.T) {
 		{
 			name:                "nil catalog",
 			req:                 &pb.ListHostsRequest{},
-			expectedErrContains: "catalog is nil",
+			expectedErrContains: "catalog is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1170,7 +1867,7 @@ func TestPluginListHostsErr(t *testing.T) {
 					Secrets: new(structpb.Struct),
 				},
 			},
-			expectedErrContains: "catalog missing attributes",
+			expectedErrContains: "catalog attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1238,7 +1935,7 @@ func TestPluginListHostsErr(t *testing.T) {
 					},
 				},
 			},
-			expectedErrContains: "sets is nil",
+			expectedErrContains: "sets are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1264,7 +1961,7 @@ func TestPluginListHostsErr(t *testing.T) {
 				},
 				Sets: []*hostsets.HostSet{{}},
 			},
-			expectedErrContains: "set missing id",
+			expectedErrContains: "set id is required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -1294,7 +1991,7 @@ func TestPluginListHostsErr(t *testing.T) {
 					},
 				},
 			},
-			expectedErrContains: "set missing attributes",
+			expectedErrContains: "set foobar attributes are required",
 			expectedErrCode:     codes.InvalidArgument,
 		},
 		{
@@ -2047,4 +2744,55 @@ func TestAppendDistinct(t *testing.T) {
 			require.ElementsMatch(actual, tc.expected)
 		})
 	}
+}
+
+func TestDryRunValidation(t *testing.T) {
+	t.Run("nilState", func(t *testing.T) {
+		st := dryRunValidation(context.Background(), nil)
+		require.NotNil(t, st)
+		require.Equal(t, codes.InvalidArgument.String(), st.Code().String())
+		require.Equal(t, "persisted state is required", st.Message())
+	})
+
+	t.Run("ec2ClientErr", func(t *testing.T) {
+		st := dryRunValidation(context.Background(), &awsCatalogPersistedState{
+			AwsCredentialPersistedState: &credential.AwsCredentialPersistedState{
+				CredentialsConfig: &awsutil.CredentialsConfig{},
+			},
+			testEC2APIFunc: func(...aws.Config) (EC2API, error) {
+				return nil, fmt.Errorf("oops ec2 client err")
+			},
+		})
+		require.NotNil(t, st)
+		require.Equal(t, codes.InvalidArgument.String(), st.Code().String())
+		require.Equal(t, "error getting EC2 client: oops ec2 client err", st.Message())
+	})
+
+	t.Run("describeInstancesErr", func(t *testing.T) {
+		st := dryRunValidation(context.Background(), &awsCatalogPersistedState{
+			AwsCredentialPersistedState: &credential.AwsCredentialPersistedState{
+				CredentialsConfig: &awsutil.CredentialsConfig{
+					AccessKey: "AKIAfoo",
+					SecretKey: "baz",
+				},
+			},
+			testEC2APIFunc: newTestMockEC2(nil, testMockEC2WithDescribeInstancesError(fmt.Errorf("oops describe instances error"))),
+		})
+		require.NotNil(t, st)
+		require.Equal(t, codes.FailedPrecondition.String(), st.Code().String())
+		require.Equal(t, "aws describe instances failed: oops describe instances error", st.Message())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		st := dryRunValidation(context.Background(), &awsCatalogPersistedState{
+			AwsCredentialPersistedState: &credential.AwsCredentialPersistedState{
+				CredentialsConfig: &awsutil.CredentialsConfig{
+					AccessKey: "AKIAfoo",
+					SecretKey: "baz",
+				},
+			},
+			testEC2APIFunc: newTestMockEC2(nil, testMockEC2WithDescribeInstancesOutput(&ec2.DescribeInstancesOutput{})),
+		})
+		require.Nil(t, st)
+	})
 }

--- a/plugin/service/storage/plugin.go
+++ b/plugin/service/storage/plugin.go
@@ -64,7 +64,7 @@ func (p *StoragePlugin) OnCreateStorageBucket(ctx context.Context, req *pb.OnCre
 		return nil, err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (p *StoragePlugin) OnUpdateStorageBucket(ctx context.Context, req *pb.OnUpd
 	// Verify the incoming credentials are valid and return any errors to the
 	// user if they're not. Note this doesn't validate the credentials against
 	// AWS - it only does logical validation on the fields.
-	updatedCredentials, err := cred.GetCredentialsConfig(newBucket.GetSecrets(), newStorageAttributes.CredentialAttributes, false)
+	updatedCredentials, err := cred.GetCredentialsConfig(newBucket.GetSecrets(), newStorageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +318,7 @@ func (p *StoragePlugin) HeadObject(ctx context.Context, req *pb.HeadObjectReques
 		return nil, err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +386,7 @@ func (p *StoragePlugin) ValidatePermissions(ctx context.Context, req *pb.Validat
 		return nil, err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +444,7 @@ func (p *StoragePlugin) GetObject(req *pb.GetObjectRequest, stream pb.StoragePlu
 		return err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return err
 	}
@@ -555,7 +555,7 @@ func (p *StoragePlugin) PutObject(ctx context.Context, req *pb.PutObjectRequest)
 		return nil, err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}
@@ -650,7 +650,7 @@ func (p *StoragePlugin) DeleteObjects(ctx context.Context, req *pb.DeleteObjects
 		return nil, err
 	}
 
-	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes, false)
+	credConfig, err := cred.GetCredentialsConfig(bucket.GetSecrets(), storageAttributes.CredentialAttributes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit also introduces a new dry run validation step when creating or updating a host catalog. Additionally, it introduces new tests related to using AssumeRole credentials, as well as more error and success state cases.

service/host/plugin.go now closely follows service/storage/plugin.go. This is by design as to bring both "halves" of the AWS plugin into parity with each other.