### PR TITLE
test(host): update e2e testing to support shared test enviro creds

### DIFF
--- a/testing/e2e_host_test.go
+++ b/testing/e2e_host_test.go
@@ -22,8 +22,6 @@ import (
 
 const expectedEc2InstanceCount = 5
 
-var expectedTags = []string{"foo", "bar", "baz"}
-
 func TestHostPlugin(t *testing.T) {
 	region := os.Getenv("AWS_REGION")
 	if region == "" {
@@ -79,6 +77,14 @@ func TestHostPlugin(t *testing.T) {
 	ec2InstanceTags, err := tf.GetOutputMap("instance_tags")
 	require.NoError(err)
 	require.Len(ec2InstanceTags, expectedEc2InstanceCount)
+
+	rawExpectedTags, err := tf.GetOutputSlice("instance_tag_keys")
+	require.NoError(err)
+	require.Len(rawExpectedTags, 3)
+	expectedTags := make([]string, 0, len(rawExpectedTags))
+	for _, rawExpectedTag := range rawExpectedTags {
+		expectedTags = append(expectedTags, rawExpectedTag.(string))
+	}
 
 	// Start the workflow now. Set up the host catalog. Note that this
 	// will cause the state to go out of drift above in the sense that
@@ -143,13 +149,13 @@ func TestHostPlugin(t *testing.T) {
 	}
 
 	cases := [][]string{
-		{"foo"},
-		{"bar"},
-		{"baz"},
-		{"foo", "bar"},
-		{"foo", "baz"},
-		{"bar", "baz"},
-		{"foo", "bar", "baz"},
+		{expectedTags[0]},
+		{expectedTags[1]},
+		{expectedTags[2]},
+		{expectedTags[0], expectedTags[1]},
+		{expectedTags[0], expectedTags[2]},
+		{expectedTags[1], expectedTags[2]},
+		{expectedTags[0], expectedTags[1], expectedTags[2]},
 	}
 
 	for _, tc := range cases {

--- a/testing/testdata/host/iam.tf
+++ b/testing/testdata/host/iam.tf
@@ -1,24 +1,20 @@
 # Copyright IBM Corp. 2021, 2026
 # SPDX-License-Identifier: MPL-2.0
 
-variable "iam_user_prefix" {
-  default = "boundary-plugin-host-aws-test-iam-user"
-}
-
-variable "iam_user_count" {
-  default = 6
-}
-
 resource "random_id" "aws_iam_user_name" {
   count       = var.iam_user_count
-  prefix      = "${var.iam_user_prefix}-${count.index}"
+  prefix      = "demo-${local.hashicorp_email}-boundary-iam-user"
   byte_length = 4
 }
 
 resource "aws_iam_user" "user" {
-  count         = var.iam_user_count
-  name          = random_id.aws_iam_user_name[count.index].dec
-  force_destroy = true
+  count                = var.iam_user_count
+  name                 = random_id.aws_iam_user_name[count.index].dec
+  force_destroy        = true
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/DemoUser"
+  tags = {
+    "boundary-demo" = local.hashicorp_email
+  }
 }
 
 resource "aws_iam_access_key" "user_initial_key" {
@@ -26,8 +22,13 @@ resource "aws_iam_access_key" "user_initial_key" {
   user  = aws_iam_user.user[count.index].name
 }
 
+resource "random_id" "aws_ec2_policy_name" {
+  prefix      = "BoundaryPluginHost"
+  byte_length = 4
+}
+
 resource "aws_iam_policy" "ec2_describeinstances" {
-  name = "BoundaryPluginHostAwsTestDescribeInstancesPolicy"
+  name = random_id.aws_ec2_policy_name.dec
 
   policy = <<EOF
 {
@@ -51,9 +52,15 @@ resource "aws_iam_user_policy_attachment" "user_ec2_describeinstances_attachment
   policy_arn = aws_iam_policy.ec2_describeinstances.arn
 }
 
+resource "random_id" "aws_iam_policy_name" {
+  count       = var.iam_user_count
+  prefix      = "BoundaryPluginCredentials"
+  byte_length = 4
+}
+
 resource "aws_iam_policy" "user_self_manage_policy" {
   count = var.iam_user_count
-  name  = "BoundaryPluginHostAwsTestUserSelfManagePolicy-${count.index}"
+  name  = random_id.aws_iam_policy_name[count.index].dec
 
   policy = <<EOF
 {

--- a/testing/testdata/host/variable.tf
+++ b/testing/testdata/host/variable.tf
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2021, 2026
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_caller_identity" "current" {}
+
+variable "iam_user_count" {
+  default = 6
+}
+
+# We are using a shared account for testing so make sure the stale ec2
+# machine tags don't match for this test run
+resource "random_id" "foo_key" {
+  prefix      = "foo"
+  byte_length = 4
+}
+
+resource "random_id" "bar_key" {
+  prefix      = "bar"
+  byte_length = 4
+}
+
+resource "random_id" "baz_key" {
+  prefix      = "baz"
+  byte_length = 4
+}
+
+locals {
+  hashicorp_email = split(":", data.aws_caller_identity.current.user_id)[1]
+  
+  instance_tags = [
+    {
+      "${random_id.foo_key.dec}" = "true"
+    },
+    {
+      "${random_id.foo_key.dec}" = "true"
+      "${random_id.bar_key.dec}" = "true"
+    },
+    {
+      "${random_id.bar_key.dec}" = "true"
+    },
+    {
+      "${random_id.bar_key.dec}" = "true"
+      "${random_id.baz_key.dec}" = "true"
+    },
+    {
+      "${random_id.baz_key.dec}" = "true"
+    },
+  ]
+}

--- a/testing/testdata/host/vpc_ec2.tf
+++ b/testing/testdata/host/vpc_ec2.tf
@@ -1,28 +1,6 @@
 # Copyright IBM Corp. 2021, 2026
 # SPDX-License-Identifier: MPL-2.0
 
-variable "instance_tags" {
-  default = [
-    {
-      "foo" = "true",
-    },
-    {
-      "foo" = "true",
-      "bar" = "true",
-    },
-    {
-      "bar" = "true",
-    },
-    {
-      "bar" = "true",
-      "baz" = "true",
-    },
-    {
-      "baz" = "true",
-    },
-  ]
-}
-
 data "aws_availability_zones" "azs" {}
 
 data "aws_ami" "ubuntu" {
@@ -52,12 +30,12 @@ resource "aws_subnet" "subnet" {
 }
 
 resource "aws_instance" "instances" {
-  count         = length(var.instance_tags)
+  count         = length(local.instance_tags)
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t3.nano"
   subnet_id     = aws_subnet.subnet.id
 
-  tags = var.instance_tags[count.index]
+  tags = local.instance_tags[count.index]
 }
 
 output "instance_ids" {
@@ -74,4 +52,12 @@ output "instance_tags" {
   value = {
     for _, r in aws_instance.instances : r.id => r.tags
   }
+}
+
+output "instance_tag_keys" {
+  value = [
+    random_id.foo_key.dec,
+    random_id.bar_key.dec,
+    random_id.baz_key.dec,
+  ]
 }


### PR DESCRIPTION
## Summary

This updates host e2e tests to follow the `demo-` user naming policy we have, it also adds a few random variables to remove naming conflicts when running a few times while stale resources are still around

```
go test -run TestHostPlugin -count=1 -v -timeout 10m
=== RUN   TestHostPlugin
    e2e_host_test.go:42: ===== deploying test Terraform workspace =====
    e2e_host_test.go:101: testing OnCreateCatalog (region=us-east-1, rotate=false)
    e2e_host_test.go:103: testing OnCreateCatalog (region=us-east-1, rotate=true)
    e2e_host_test.go:110: testing OnUpdateCatalog (region=us-east-1, newcreds=false, rotated=false, rotate=false)
    e2e_host_test.go:112: testing OnUpdateCatalog (region=us-east-1, newcreds=false, rotated=false, rotate=true)
    e2e_host_test.go:114: testing OnUpdateCatalog (region=us-east-1, newcreds=false, rotated=true, rotate=true)
    e2e_host_test.go:116: testing OnUpdateCatalog (region=us-east-1, newcreds=true, rotated=true, rotate=false)
    e2e_host_test.go:118: testing OnUpdateCatalog (region=us-east-1, newcreds=true, rotated=false, rotate=true)
    e2e_host_test.go:120: testing OnUpdateCatalog (region=us-east-1, newcreds=true, rotated=true, rotate=false)
    e2e_host_test.go:122: testing OnUpdateCatalog (region=us-east-1, newcreds=true, rotated=false, rotate=false)
    e2e_host_test.go:129: testing OnDeleteCatalog (region=us-east-1, rotated=false)
    e2e_host_test.go:132: testing OnDeleteCatalog (region=us-east-1, rotated=true)
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[foo4176525282])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[foo4176525282])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[foo4176525282])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[foo4176525282], expected/actual=(len=2, ids=map[i-0942870328c52c021:[hostset-0] i-0df8b7d2de258576f:[hostset-0]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[bar3629244907])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[bar3629244907])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[bar3629244907])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[bar3629244907], expected/actual=(len=3, ids=map[i-04437b99c0bf8d58c:[hostset-0] i-0b78a0f06a2dfd8c4:[hostset-0] i-0df8b7d2de258576f:[hostset-0]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[baz4270793414])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[baz4270793414])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[baz4270793414])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[baz4270793414], expected/actual=(len=2, ids=map[i-04437b99c0bf8d58c:[hostset-0] i-0629d73682f1a9ecb:[hostset-0]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[foo4176525282 bar3629244907])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[foo4176525282 bar3629244907])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[foo4176525282 bar3629244907])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[foo4176525282 bar3629244907], expected/actual=(len=4, ids=map[i-04437b99c0bf8d58c:[hostset-1] i-0942870328c52c021:[hostset-0] i-0b78a0f06a2dfd8c4:[hostset-1] i-0df8b7d2de258576f:[hostset-0 hostset-1]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[foo4176525282 baz4270793414])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[foo4176525282 baz4270793414])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[foo4176525282 baz4270793414])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[foo4176525282 baz4270793414], expected/actual=(len=4, ids=map[i-04437b99c0bf8d58c:[hostset-1] i-0629d73682f1a9ecb:[hostset-1] i-0942870328c52c021:[hostset-0] i-0df8b7d2de258576f:[hostset-0]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[bar3629244907 baz4270793414])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[bar3629244907 baz4270793414])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[bar3629244907 baz4270793414])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[bar3629244907 baz4270793414], expected/actual=(len=4, ids=map[i-04437b99c0bf8d58c:[hostset-0 hostset-1] i-0629d73682f1a9ecb:[hostset-1] i-0b78a0f06a2dfd8c4:[hostset-0] i-0df8b7d2de258576f:[hostset-0]]))
    e2e_host_test.go:163: testing OnCreateSet (region=us-east-1, tags=[foo4176525282 bar3629244907 baz4270793414])
    e2e_host_test.go:163: testing OnUpdateSet (region=us-east-1, tags=[foo4176525282 bar3629244907 baz4270793414])
    e2e_host_test.go:165: testing ListHosts (region=us-east-1, tags=[foo4176525282 bar3629244907 baz4270793414])
    e2e_host_test.go:165: testing ListHosts: success (region=us-east-1, tags=[foo4176525282 bar3629244907 baz4270793414], expected/actual=(len=5, ids=map[i-04437b99c0bf8d58c:[hostset-1 hostset-2] i-0629d73682f1a9ecb:[hostset-2] i-0942870328c52c021:[hostset-0] i-0b78a0f06a2dfd8c4:[hostset-1] i-0df8b7d2de258576f:[hostset-0 hostset-1]]))
    e2e_host_test.go:47: ===== destroying test Terraform workspace =====
--- PASS: TestHostPlugin (187.32s)
PASS
ok  	github.com/hashicorp/boundary-plugin-aws/testing	188.101s
```

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.